### PR TITLE
Make sure `m_state` with internal linkage is defined

### DIFF
--- a/HwBpLib/test/test.cpp
+++ b/HwBpLib/test/test.cpp
@@ -12,6 +12,7 @@ namespace
     {
         static GlobalState& Get()
         {
+            static GlobalState m_state;
             return m_state;
         }
 
@@ -41,8 +42,6 @@ namespace
             m_breakPointFound = 0;
         }
 
-        static GlobalState m_state;
-         
         int m_breakPointFound;
     };
 


### PR DESCRIPTION
Fixes the following error when building: error C7631: 'm_state': variable with internal linkage declared but not defined